### PR TITLE
convert back to float8 like dequantize->quantize

### DIFF
--- a/protoquant/float8/experiments.py
+++ b/protoquant/float8/experiments.py
@@ -1,0 +1,34 @@
+import copy
+import random
+import unittest
+
+import torch
+import torch.nn as nn
+
+from float8_utils import (
+    float32_to_float8,
+    float8_to_float32,
+    E4M3,
+    E5M2,
+    compute_error,
+    tensor_to_scale,
+)
+from float8_tensor import Float8Tensor
+from float8_linear import Float8Linear
+
+
+if __name__ == "__main__":
+    # Create a float32 precision tensor
+    x = torch.randn(128)
+
+    # Create FP8 tensor from the above full precision tensor
+    x_fp8 = Float8Tensor.from_float32(x, tensor_to_scale(x, E4M3), E4M3)
+
+    # Inspect fp8 tensor before nn.uniform_
+    print(x_fp8)
+
+    # Call init.uniform_
+    torch.nn.init.uniform_(x_fp8)
+
+    # Inspect fp8 tensor after nn.uniform_
+    print(x_fp8)

--- a/protoquant/float8/float8_tensor.py
+++ b/protoquant/float8/float8_tensor.py
@@ -137,12 +137,15 @@ class Float8Tensor(torch.Tensor):
             return t
 
         args = tree_map(maybe_unwrap, args)
-        args = tree_map(maybe_wrap, args)
         if kwargs is not None:
             kwargs = tree_map(maybe_unwrap, kwargs)
-            kwargs = tree_map(maybe_wrap, kwargs)
 
         out = super().__torch_dispatch__(func, types, args, kwargs)
+
+        if func is aten.uniform_.default:
+            args = tree_map(maybe_wrap, args)
+        print("after ", args)
+
         return out
 
     # Do not force the Float8Tensor type on the returned tensor


### PR DESCRIPTION
Experiments with FP8 PoC 

```
import copy
import random
import unittest

import torch
import torch.nn as nn

from float8_utils import (
    float32_to_float8,
    float8_to_float32,
    E4M3,
    E5M2,
    compute_error,
    tensor_to_scale,
)
from float8_tensor import Float8Tensor
from float8_linear import Float8Linear


x = torch.randn(2)
scale_tensor = torch.tensor(1.0)
scale_tensor.fill_(tensor_to_scale(x, E4M3))
x_fp8 = Float8Tensor.from_float32(x, scale_tensor, E4M3)
print(x_fp8)
torch.nn.init.uniform_(x_fp8)
print(x_fp8)
```